### PR TITLE
fixed the navigation stack to & back from an activity to the doctor page

### DIFF
--- a/app/src/main/java/com/sh/hospitaldata/MainActivity.java
+++ b/app/src/main/java/com/sh/hospitaldata/MainActivity.java
@@ -44,8 +44,9 @@ public class MainActivity extends AppCompatActivity {
                 super.onAuthenticationSucceeded(result);
                 runOnUiThread(() -> {
                     Toast.makeText(getApplicationContext(), "Doctor authenticated ", Toast.LENGTH_SHORT).show();
-                    // Launch AddRecordActivity
+                    // Launch DoctorUserPage and clear the activity stack
                     Intent intent = new Intent(MainActivity.this, com.sh.hospitaldata.data.DoctorUserPage.class);
+                    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                     startActivity(intent);
                 });
             }
@@ -53,16 +54,16 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
                 super.onAuthenticationError(errorCode, errString);
-                runOnUiThread(() -> 
-                    Toast.makeText(getApplicationContext(), "Authentication error: " + errString, Toast.LENGTH_SHORT).show()
+                runOnUiThread(() ->
+                        Toast.makeText(getApplicationContext(), "Authentication error: " + errString, Toast.LENGTH_SHORT).show()
                 );
             }
 
             @Override
             public void onAuthenticationFailed() {
                 super.onAuthenticationFailed();
-                runOnUiThread(() -> 
-                    Toast.makeText(getApplicationContext(), "Face not recognized ", Toast.LENGTH_SHORT).show()
+                runOnUiThread(() ->
+                        Toast.makeText(getApplicationContext(), "Face not recognized ", Toast.LENGTH_SHORT).show()
                 );
             }
         });


### PR DESCRIPTION
fixed the navigation stack to basically:
Code 
The key changes are in the onAuthenticationSucceeded method:

java
// Launch DoctorUserPage and clear the activity stack
Intent intent = new Intent(MainActivity.this, com.sh.hospitaldata.data.DoctorUserPage.class);
intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
startActivity(intent);
What these flags do:
FLAG_ACTIVITY_NEW_TASK: Creates a new task for the activity
FLAG_ACTIVITY_CLEAR_TASK: Clears any existing activities in the task before starting the new one
Result:
Now when you navigate like this:

Login → Doctor Auth → DoctorUserPage → AddRecordActivity
Press back → Goes directly to DoctorUserPage (not login)
Press back from DoctorUserPage → Exits the app (since login is cleared from stack)
This creates a clean navigation experience where users can't accidentally go back to the login screen after authentication, and the back button works intuitively within the doctor workflow.